### PR TITLE
Fix £800 tooltip centering and homepage heading double line-break

### DIFF
--- a/components/ClaudiaLandingPage/LPHero.js
+++ b/components/ClaudiaLandingPage/LPHero.js
@@ -28,8 +28,6 @@ export const LPHero = () => {
           <div className="text-center lg:text-left">
             <h1 className="text-2xl sm:text-3xl md:text-4xl lg:text-[2.85rem] font-bold text-white mb-3 sm:mb-4 leading-normal sm:leading-tight" style={{ fontWeight: 700 }}>
               The ADHD Companion
-              <br className="sm:hidden" />
-              {' '}
               <br />
               <span className="text-[#30bcd9]">that <span className="italic">actually</span> works.</span>
             </h1>

--- a/pages/forclinics.js
+++ b/pages/forclinics.js
@@ -199,7 +199,7 @@ const App = () => {
         .tooltip-container:hover .tooltip-text {
           visibility: visible;
           opacity: 1;
-          transform: translateY(0);
+          transform: translateX(-50%);
         }
         
         /* Custom Scrollbar */


### PR DESCRIPTION
forclinics – £800 tooltip:
The CSS hover rule was overwriting Tailwind's translateX(-50%) with translateY(0), stripping the horizontal centering so the tooltip started from the centre of its anchor and ran off-screen to the right. Changed the rule to transform: translateX(-50%) so centring is preserved.

Homepage heading (LPHero):
On mobile there were two <br> tags – a sm:hidden one plus an unconditional one – creating a blank line between "The ADHD Companion" and "that actually works.". Removed the sm:hidden break and the stray space so mobile now matches the single-break desktop layout shown in the designs.

https://claude.ai/code/session_01PbaN2xhPR2LRQTpP4BoDLj