### PR TITLE
Add 'For Coaches' page

### DIFF
--- a/components/NEWClaudiaLPHeader.js
+++ b/components/NEWClaudiaLPHeader.js
@@ -179,6 +179,25 @@ const NEWClaudiaLPHeader = () => {
                     <div className="text-xs text-white/50">Support neurodiverse employees</div>
                   </div>
                 </Link>
+                <div className="border-t border-white/5"></div>
+                <Link
+                  href="/forcoaches"
+                  className="flex items-center gap-3 px-4 py-3.5 text-white/90 hover:text-white hover:bg-white/10 transition-all duration-200 text-sm font-medium"
+                  onClick={() => {
+                    track('For Coaches');
+                    setForDropdownOpen(false);
+                  }}
+                >
+                  <span className="w-8 h-8 rounded-lg bg-purple-500/10 flex items-center justify-center flex-shrink-0">
+                    <svg className="w-4 h-4 text-purple-400" fill="none" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" viewBox="0 0 24 24" stroke="currentColor">
+                      <path d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z" />
+                    </svg>
+                  </span>
+                  <div>
+                    <div className="text-sm font-medium">For Coaches</div>
+                    <div className="text-xs text-white/50">Support clients between sessions</div>
+                  </div>
+                </Link>
               </div>
               )}
             </div>
@@ -310,6 +329,21 @@ const NEWClaudiaLPHeader = () => {
                       </svg>
                     </span>
                     For Corporates
+                  </Link>
+                  <Link
+                    href="/forcoaches"
+                    className="text-white/80 hover:text-white hover:bg-white/10 transition-all duration-200 text-sm py-2.5 px-4 rounded-lg font-medium flex items-center gap-3"
+                    onClick={() => {
+                      track('For Coaches from mobile menu');
+                      setMobileMenuOpen(false);
+                    }}
+                  >
+                    <span className="w-7 h-7 rounded-md bg-purple-500/10 flex items-center justify-center flex-shrink-0">
+                      <svg className="w-3.5 h-3.5 text-purple-400" fill="none" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" viewBox="0 0 24 24" stroke="currentColor">
+                        <path d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z" />
+                      </svg>
+                    </span>
+                    For Coaches
                   </Link>
                 </div>
               )}

--- a/pages/api/coach-enquiry.js
+++ b/pages/api/coach-enquiry.js
@@ -1,0 +1,56 @@
+// pages/api/coach-enquiry.js
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+    return;
+  }
+
+  const { firstName, email, isCoach } = req.body;
+  const listId = process.env.NEXT_PUBLIC_MOOSEND_LIST_ID;
+  const apiKey = process.env.NEXT_PUBLIC_MOOSEND_API_KEY;
+
+  if (!firstName || !email || !listId || !apiKey) {
+    res.status(400).json({ error: 'Missing required fields' });
+    return;
+  }
+
+  const url = `https://api.moosend.com/v3/subscribers/${listId}/subscribe.json?apikey=${apiKey}`;
+
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+      },
+      body: JSON.stringify({
+        Name: firstName,
+        Email: email,
+        CustomFields: [
+          `is_coach=${isCoach ? 'Yes' : 'No'}`,
+          `source=For Coaches Page`,
+        ],
+      }),
+    });
+
+    const text = await response.text();
+    console.log('Moosend API response (coach-enquiry):', text);
+
+    try {
+      const data = JSON.parse(text);
+
+      if (response.ok) {
+        res.status(200).json(data);
+      } else {
+        res.status(response.status).json({ error: data });
+      }
+    } catch (jsonError) {
+      console.error('Failed to parse JSON response:', jsonError);
+      res.status(500).json({ error: 'Failed to parse JSON response from Moosend' });
+    }
+  } catch (error) {
+    console.error('Internal server error:', error);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+}

--- a/pages/forcoaches.js
+++ b/pages/forcoaches.js
@@ -1,0 +1,588 @@
+import React, { useState } from 'react';
+import Head from 'next/head';
+import { 
+  ArrowRight, 
+  X,
+  CheckCircle2,
+  CalendarCheck,
+  Brain,
+  Zap,
+  TrendingUp,
+  Mic,
+  Users,
+  Star,
+  Shield,
+  BarChart3,
+  Clock,
+  Heart,
+  Menu
+} from 'lucide-react';
+
+import { LPFooter } from '../components/ClaudiaLandingPage/LPFooter';
+import { Toaster } from '../components/ui/toaster';
+
+// --- Coach Page Header ---
+const CoachPageHeader = ({ onGetStartedClick }) => {
+  const [scrolled, setScrolled] = useState(false);
+
+  React.useEffect(() => {
+    const handleScroll = () => setScrolled(window.scrollY > 20);
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  return (
+    <header
+      className={`fixed top-0 left-0 right-0 z-50 transition-all duration-500 ease-out py-3 px-4 sm:py-4 sm:px-6 overflow-x-hidden ${
+        scrolled
+          ? "bg-[#1e2a4a]/90 backdrop-blur-md shadow-sm border-b border-white/10"
+          : "bg-transparent"
+      }`}
+    >
+      <div className="flex items-center justify-between max-w-[1400px] mx-auto w-full">
+        <a href="https://www.neuro-notion.com" target="_blank" rel="noopener noreferrer" className="flex items-center space-x-2">
+          <img
+            src="https://NeuroNotionPullZonw.b-cdn.net/Secondary%20logo.png"
+            alt="Neuro Logo"
+            className="h-7 sm:h-8 w-auto"
+          />
+          <span className="hidden sm:inline text-xl font-semibold tracking-tight text-white">Claudia by Neuro</span>
+          <span className="sm:hidden text-lg font-semibold tracking-tight text-white">Neuro</span>
+        </a>
+
+        <div className="flex items-center gap-2 sm:gap-3">
+          <a
+            href="#pricing"
+            className="text-slate-300 hover:text-white font-medium py-1.5 px-3 sm:px-4 rounded-xl text-[11px] sm:text-sm transition-colors duration-200 whitespace-nowrap"
+          >
+            Pricing
+          </a>
+          <button
+            className="bg-[#0EA5E9] hover:bg-[#0284C7] text-white font-bold py-1.5 px-3 sm:px-4 rounded-xl text-[11px] sm:text-sm transform hover:scale-105 transition-all duration-300 whitespace-nowrap"
+            style={{ fontWeight: 700 }}
+            onClick={onGetStartedClick}
+          >
+            Get Started
+          </button>
+        </div>
+      </div>
+    </header>
+  );
+};
+
+// --- Moosend Form Modal ---
+const MoosendFormModal = ({ isOpen, onClose }) => {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [isCoach, setIsCoach] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState('');
+
+  if (!isOpen) return null;
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!name.trim() || !email.trim()) {
+      setError('Please fill in all fields.');
+      return;
+    }
+    setIsSubmitting(true);
+    setError('');
+
+    try {
+      const response = await fetch('/api/coach-enquiry', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ firstName: name, email, isCoach }),
+      });
+
+      if (!response.ok) throw new Error('Failed to submit');
+      setSubmitted(true);
+    } catch (err) {
+      setError('Something went wrong. Please try again or email josh@neuro-notion.com directly.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleClose = () => {
+    onClose();
+    setSubmitted(false);
+    setError('');
+    setName('');
+    setEmail('');
+    setIsCoach(true);
+  };
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-slate-900/80 backdrop-blur-sm animate-in fade-in duration-200">
+      <div className="bg-[#1E293B] border border-slate-700 rounded-2xl shadow-2xl w-full max-w-lg overflow-visible relative animate-in zoom-in-95 duration-300">
+        <button 
+          onClick={handleClose}
+          className="absolute top-4 right-4 text-slate-400 hover:text-white transition-colors"
+        >
+          <X size={24} />
+        </button>
+
+        {submitted ? (
+          <div className="p-8 text-center">
+            <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full border border-emerald-500/20 bg-emerald-500/10">
+              <CheckCircle2 size={28} className="text-emerald-400" />
+            </div>
+            <h3 className="mb-3 font-poppins text-2xl font-bold text-white">Thanks! We have your details.</h3>
+            <p className="mx-auto max-w-md leading-relaxed text-slate-300">A member of the team will be in touch within one business day.</p>
+          </div>
+        ) : (
+          <div className="p-8">
+            <div className="text-center mb-6">
+              <div className="w-14 h-14 bg-[#0EA5E9]/10 rounded-full flex items-center justify-center mx-auto mb-4">
+                <Heart size={28} className="text-[#0EA5E9]" />
+              </div>
+              <h3 className="text-2xl font-bold text-white mb-2 font-poppins">Get started with Claudia for Coaches</h3>
+              <p className="text-slate-400 text-sm">Fill in your details and we will get you set up.</p>
+            </div>
+
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div>
+                <label className="mb-2 block text-sm text-slate-300">Name</label>
+                <input
+                  type="text"
+                  required
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="Your name"
+                  className="w-full rounded-xl border border-slate-700 bg-slate-900 px-4 py-3 text-white focus:border-[#38BDF8] focus:outline-none"
+                />
+              </div>
+              <div>
+                <label className="mb-2 block text-sm text-slate-300">Email</label>
+                <input
+                  type="email"
+                  required
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="you@example.com"
+                  className="w-full rounded-xl border border-slate-700 bg-slate-900 px-4 py-3 text-white focus:border-[#38BDF8] focus:outline-none"
+                />
+              </div>
+              <div className="flex items-center gap-3 py-2">
+                <button
+                  type="button"
+                  onClick={() => setIsCoach(!isCoach)}
+                  className={`w-6 h-6 rounded-md border-2 flex items-center justify-center transition-all ${isCoach ? 'bg-[#0EA5E9] border-[#0EA5E9]' : 'border-slate-600 bg-transparent'}`}
+                >
+                  {isCoach && <CheckCircle2 size={14} className="text-white" />}
+                </button>
+                <span className="text-slate-300 text-sm">Yes, I am a coach</span>
+              </div>
+
+              {error && <div className="rounded-xl border border-red-500/20 bg-red-500/10 p-3 text-sm text-red-300">{error}</div>}
+
+              <button
+                type="submit"
+                disabled={isSubmitting}
+                className={`w-full rounded-xl py-3.5 font-semibold text-white transition-colors ${isSubmitting ? 'cursor-not-allowed bg-[#0EA5E9]/70' : 'bg-[#0EA5E9] hover:bg-[#0284C7]'}`}
+              >
+                {isSubmitting ? 'Sending...' : 'Get Started'}
+              </button>
+            </form>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+// --- Main CTA Modal (two options) ---
+const CTAModal = ({ isOpen, onClose, onOpenForm }) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-slate-900/80 backdrop-blur-sm animate-in fade-in duration-200">
+      <div className="bg-[#1E293B] border border-slate-700 rounded-2xl shadow-2xl w-full max-w-lg overflow-visible relative animate-in zoom-in-95 duration-300">
+        <button 
+          onClick={onClose}
+          className="absolute top-4 right-4 text-slate-400 hover:text-white transition-colors"
+        >
+          <X size={24} />
+        </button>
+        
+        <div className="p-8 text-center">
+          <div className="w-16 h-16 bg-[#0EA5E9]/10 rounded-full flex items-center justify-center mx-auto mb-6">
+            <CalendarCheck size={32} className="text-[#0EA5E9]" />
+          </div>
+          
+          <h3 className="text-2xl font-bold text-white mb-3 font-poppins leading-tight">
+            Get Claudia for your coaching practice
+          </h3>
+          <p className="text-slate-400 text-base leading-relaxed mb-8">
+            Choose how you would like to get started.
+          </p>
+          
+          <div className="space-y-4">
+            <a 
+              href="https://app.usemotion.com/meet/josh-budd/meeting" 
+              target="_blank" 
+              rel="noopener noreferrer"
+              className="block w-full bg-[#0EA5E9] hover:bg-[#0284C7] text-white font-bold text-lg py-4 rounded-xl transition-all shadow-lg shadow-cyan-500/25 hover:shadow-cyan-500/40 hover:-translate-y-1"
+            >
+              Talk to the Founder
+            </a>
+            
+            <button
+              onClick={() => {
+                onClose();
+                onOpenForm();
+              }}
+              className="block w-full bg-transparent border-2 border-slate-600 hover:border-[#0EA5E9] text-white font-bold text-lg py-4 rounded-xl transition-all hover:-translate-y-1"
+            >
+              Send us your details
+            </button>
+          </div>
+          
+          <p className="mt-5 text-xs text-slate-500">
+            We will get back to you within one business day.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// --- Benefit Card ---
+const BenefitCard = ({ icon, title, desc }) => (
+  <div className="glass-card p-8 rounded-2xl hover:border-slate-500 transition-all hover:scale-[1.02] group h-full flex flex-col">
+    <div className="mb-6 group-hover:scale-110 transition-transform duration-300 bg-slate-800/50 w-16 h-16 rounded-xl flex items-center justify-center border border-slate-700">
+      {icon}
+    </div>
+    <h3 className="text-xl font-bold mb-3 font-poppins text-white">{title}</h3>
+    <p className="text-slate-400 leading-relaxed text-sm flex-grow">{desc}</p>
+  </div>
+);
+
+// --- Feature Card ---
+const FeatureCard = ({ icon, title, desc, color, bg }) => (
+  <div className="glass-card p-6 h-full flex flex-col rounded-2xl hover:-translate-y-1 transition-transform duration-300 group hover:border-slate-600">
+    <div className={`w-12 h-12 ${bg} ${color} rounded-xl flex items-center justify-center mb-5 group-hover:scale-110 transition-transform`}>
+      {icon}
+    </div>
+    <h3 className="text-lg font-bold text-white mb-2 font-poppins">{title}</h3>
+    <p className="text-slate-400 leading-relaxed flex-grow text-sm">{desc}</p>
+  </div>
+);
+
+// --- Main Page Component ---
+const ForCoaches = () => {
+  const [isCtaModalOpen, setIsCtaModalOpen] = useState(false);
+  const [isFormModalOpen, setIsFormModalOpen] = useState(false);
+
+  const openCtaModal = () => setIsCtaModalOpen(true);
+  const closeCtaModal = () => setIsCtaModalOpen(false);
+  const openFormModal = () => setIsFormModalOpen(true);
+  const closeFormModal = () => setIsFormModalOpen(false);
+
+  return (
+    <>
+      <Head>
+        <title>Claudia by Neuro - For ADHD Coaches</title>
+        <meta name="description" content="Give your ADHD coaching clients 24/7 support between sessions. Claudia by Neuro helps your clients implement what you teach, when you are not available." />
+      </Head>
+
+      <CoachPageHeader onGetStartedClick={openCtaModal} />
+      
+      <div className="min-h-screen bg-[#0F172A] text-white selection:bg-[#0EA5E9] selection:text-white font-lexend overflow-x-hidden">
+      
+      {/* Font Imports & Styles */}
+      <style>{`
+        @import url('https://fonts.googleapis.com/css2?family=Lexend+Deca:wght@300;400;500;600&family=Poppins:wght@400;500;600;700;800&display=swap');
+        
+        .font-poppins { font-family: 'Poppins', sans-serif; }
+        .font-lexend { font-family: 'Lexend Deca', sans-serif; }
+        
+        .glass-card { 
+          background: rgba(30, 41, 59, 0.7); 
+          backdrop-filter: blur(12px); 
+          border: 1px solid rgba(255, 255, 255, 0.08);
+          box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+        }
+        
+        .hero-glow {
+          background: radial-gradient(circle at 50% 50%, rgba(14, 165, 233, 0.15) 0%, rgba(15, 23, 42, 0) 70%);
+        }
+      `}</style>
+
+      <CTAModal isOpen={isCtaModalOpen} onClose={closeCtaModal} onOpenForm={openFormModal} />
+      <MoosendFormModal isOpen={isFormModalOpen} onClose={closeFormModal} />
+
+      {/* Hero Section */}
+      <section className="pt-20 pb-20 lg:pt-32 lg:pb-28 px-6 relative overflow-hidden">
+        <div className="absolute top-0 left-1/2 -translate-x-1/2 w-full max-w-7xl h-[800px] hero-glow pointer-events-none -z-10"></div>
+        <div className="absolute top-20 right-0 w-96 h-96 bg-purple-500/10 rounded-full blur-3xl -z-10"></div>
+        <div className="absolute bottom-0 left-0 w-96 h-96 bg-cyan-500/10 rounded-full blur-3xl -z-10"></div>
+
+        <div className="max-w-4xl mx-auto text-center relative z-10">
+          
+          <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-slate-800/50 border border-slate-700 text-cyan-400 font-medium text-xs mb-8 backdrop-blur-sm">
+            <span className="flex h-2 w-2 rounded-full bg-cyan-400 animate-pulse"></span>
+            Built specifically for ADHD coaches
+          </div>
+          
+          <h1 className="font-poppins font-bold text-4xl md:text-6xl tracking-tight mb-8 leading-[1.15]">
+            Give Your Clients Support<br/>
+            <span className="text-transparent bg-clip-text bg-gradient-to-r from-[#0EA5E9] to-[#6366F1]">Between Every Session</span>
+          </h1>
+          
+          <p className="text-lg md:text-xl text-slate-400 mb-12 max-w-2xl mx-auto leading-relaxed font-light">
+            Your clients wake up at 1am overwhelmed. They need to plan their day and nobody is there. Claudia gives them someone to talk to when you are not available, helping them implement everything you work on together.
+          </p>
+
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-5">
+            <button 
+              onClick={openCtaModal}
+              className="w-full sm:w-auto px-8 py-4 bg-[#0EA5E9] hover:bg-[#0284C7] text-white rounded-xl font-semibold text-lg transition-all shadow-lg shadow-cyan-500/25 flex items-center justify-center gap-2 hover:-translate-y-1"
+            >
+              Get Started
+              <ArrowRight size={20} />
+            </button>
+            <a href="#how-it-works" className="w-full sm:w-auto px-8 py-4 bg-transparent border border-slate-600 hover:border-slate-400 text-white rounded-xl font-semibold text-lg transition-all flex items-center justify-center gap-2 hover:bg-slate-800/50">
+              See how it works
+            </a>
+          </div>
+        </div>
+      </section>
+
+      {/* The Problem Section */}
+      <section className="py-20 bg-[#0B1120] border-y border-slate-800">
+        <div className="max-w-4xl mx-auto px-6 text-center">
+          <div className="inline-block px-3 py-1 bg-[#0EA5E9]/10 text-[#0EA5E9] border border-[#0EA5E9]/20 rounded-full font-medium text-xs mb-4">The Gap</div>
+          <h2 className="font-poppins font-bold text-3xl md:text-4xl text-white mb-6 leading-tight">
+            Coaching sessions are powerful.<br/>But what happens in between?
+          </h2>
+          <p className="text-slate-400 text-lg leading-relaxed max-w-2xl mx-auto mb-12">
+            Your clients leave sessions motivated and clear. Then real life hits. They get overwhelmed, they forget the plan, and they spiral before the next session. The gap between sessions is where progress goes to die.
+          </p>
+
+          <div className="grid sm:grid-cols-3 gap-6 text-left">
+            <div className="bg-[#1E293B] p-6 rounded-xl border border-slate-700">
+              <Clock className="text-red-400 mb-4" size={28} />
+              <h3 className="text-white font-bold mb-2 font-poppins">The 1am panic</h3>
+              <p className="text-slate-400 text-sm leading-relaxed">Your client wakes up overwhelmed. They need help breaking something down. You are asleep. They spiral.</p>
+            </div>
+            <div className="bg-[#1E293B] p-6 rounded-xl border border-slate-700">
+              <Brain className="text-orange-400 mb-4" size={28} />
+              <h3 className="text-white font-bold mb-2 font-poppins">The implementation gap</h3>
+              <p className="text-slate-400 text-sm leading-relaxed">They know what to do. They just cannot get started. Without support in the moment, the plan stays a plan.</p>
+            </div>
+            <div className="bg-[#1E293B] p-6 rounded-xl border border-slate-700">
+              <TrendingUp className="text-yellow-400 mb-4" size={28} />
+              <h3 className="text-white font-bold mb-2 font-poppins">Slow progress</h3>
+              <p className="text-slate-400 text-sm leading-relaxed">Without daily reinforcement, clients take months to build habits that could take weeks with the right support system.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Solution Section */}
+      <section id="how-it-works" className="py-24 bg-[#0F172A] relative">
+        <div className="max-w-7xl mx-auto px-6 relative z-10">
+          <div className="text-center max-w-3xl mx-auto mb-16">
+            <div className="inline-block px-3 py-1 bg-[#0EA5E9]/10 text-[#0EA5E9] border border-[#0EA5E9]/20 rounded-full font-medium text-xs mb-4">The Solution</div>
+            <h2 className="font-poppins font-bold text-3xl md:text-5xl mb-6 text-white">A 24/7 support system your clients can use between sessions</h2>
+            <p className="text-xl text-slate-400 font-light">
+              Claudia is not here to replace you. She is here to help your clients implement what you teach, exactly when they need it most.
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
+            <BenefitCard 
+              icon={<Mic size={32} className="text-purple-400"/>}
+              title="Someone to talk to at 1am"
+              desc="When your client wakes up overwhelmed, they can speak to Claudia. She helps them process, plan, and calm down so they can get back to sleep."
+            />
+            <BenefitCard 
+              icon={<Zap size={32} className="text-cyan-400"/>}
+              title="Break tasks down in the moment"
+              desc="When they are staring at a task and cannot start, Claudia breaks it into micro-steps. The same approach you would use, available instantly."
+            />
+            <BenefitCard 
+              icon={<Brain size={32} className="text-emerald-400"/>}
+              title="Reinforce your coaching"
+              desc="Claudia helps your clients follow through on the strategies you build together. She is an extension of your practice, not a replacement."
+            />
+            <BenefitCard 
+              icon={<Clock size={32} className="text-orange-400"/>}
+              title="Daily planning support"
+              desc="Every morning, your clients can talk through their day with Claudia. She helps them prioritise, time-block, and set realistic expectations."
+            />
+            <BenefitCard 
+              icon={<Heart size={32} className="text-pink-400"/>}
+              title="Emotional regulation"
+              desc="When they are overwhelmed or stuck in a loop, Claudia helps them regulate. Grounding techniques, reframing, and gentle accountability."
+            />
+            <BenefitCard 
+              icon={<Shield size={32} className="text-yellow-400"/>}
+              title="Built for ADHD brains"
+              desc="This is not a generic chatbot. Claudia is designed from the ground up for how ADHD brains think, process, and get things done."
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* Analytics Section */}
+      <section className="py-24 bg-[#0B1120] border-y border-slate-800">
+        <div className="max-w-5xl mx-auto px-6">
+          <div className="text-center mb-12">
+            <div className="inline-block px-3 py-1 bg-[#0EA5E9]/10 text-[#0EA5E9] border border-[#0EA5E9]/20 rounded-full font-medium text-xs mb-4">Coach Dashboard</div>
+            <h2 className="font-poppins font-bold text-3xl md:text-4xl text-white mb-6">See how each client is doing over time</h2>
+            <p className="text-slate-400 text-lg max-w-2xl mx-auto leading-relaxed">
+              Track your clients&apos; progress between sessions. See their engagement, mood patterns, and how well they are implementing the strategies you work on together.
+            </p>
+          </div>
+
+          {/* Analytics Placeholder */}
+          <div className="relative max-w-4xl mx-auto">
+            <div className="w-full aspect-[16/9] bg-slate-800/50 rounded-2xl border-2 border-dashed border-slate-600 flex items-center justify-center">
+              <div className="text-center p-8">
+                <BarChart3 size={48} className="text-slate-500 mx-auto mb-4" />
+                <p className="text-slate-400 text-lg font-medium">Coach Analytics Dashboard</p>
+                <p className="text-slate-500 text-sm mt-2">Track individual client progress over time</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Why Coaches Love It Section */}
+      <section className="py-24 bg-[#0F172A]">
+        <div className="max-w-5xl mx-auto px-6">
+          <div className="text-center mb-16">
+            <div className="inline-block px-3 py-1 bg-[#0EA5E9]/10 text-[#0EA5E9] border border-[#0EA5E9]/20 rounded-full font-medium text-xs mb-4">Competitive Edge</div>
+            <h2 className="font-poppins font-bold text-3xl md:text-4xl text-white mb-6">Differentiate yourself in a saturated market</h2>
+            <p className="text-slate-400 text-lg max-w-2xl mx-auto leading-relaxed">
+              The ADHD coaching market is crowded. Claudia gives you an unfair advantage that makes your coaching more effective, your reviews better, and your referrals stronger.
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 gap-8">
+            <div className="bg-[#1E293B] p-8 rounded-2xl border border-slate-700 hover:border-slate-500 transition-all">
+              <Star className="text-yellow-400 mb-5" size={32} />
+              <h3 className="text-xl font-bold text-white mb-3 font-poppins">Better reviews</h3>
+              <p className="text-slate-400 leading-relaxed">When your clients get results faster because they have support between sessions, they leave better reviews. Better reviews mean more clients.</p>
+            </div>
+            <div className="bg-[#1E293B] p-8 rounded-2xl border border-slate-700 hover:border-slate-500 transition-all">
+              <Users className="text-emerald-400 mb-5" size={32} />
+              <h3 className="text-xl font-bold text-white mb-3 font-poppins">More referrals</h3>
+              <p className="text-slate-400 leading-relaxed">Clients who see real progress tell their friends. Claudia accelerates that progress, which accelerates your word-of-mouth growth.</p>
+            </div>
+            <div className="bg-[#1E293B] p-8 rounded-2xl border border-slate-700 hover:border-slate-500 transition-all">
+              <TrendingUp className="text-cyan-400 mb-5" size={32} />
+              <h3 className="text-xl font-bold text-white mb-3 font-poppins">10x return on investment</h3>
+              <p className="text-slate-400 leading-relaxed">At just £50 a month, one extra client from better reviews pays for Claudia many times over. The ROI is not even close.</p>
+            </div>
+            <div className="bg-[#1E293B] p-8 rounded-2xl border border-slate-700 hover:border-slate-500 transition-all">
+              <Shield className="text-purple-400 mb-5" size={32} />
+              <h3 className="text-xl font-bold text-white mb-3 font-poppins">Stand out from every other coach</h3>
+              <p className="text-slate-400 leading-relaxed">Most coaches offer sessions. You offer sessions plus a complete support system. That is a fundamentally different proposition to potential clients.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Pricing Section */}
+      <section id="pricing" className="py-24 bg-[#0B1120] border-y border-slate-800">
+        <div className="max-w-3xl mx-auto px-6 text-center">
+          <div className="inline-block px-3 py-1 bg-[#0EA5E9]/10 text-[#0EA5E9] border border-[#0EA5E9]/20 rounded-full font-medium text-xs mb-4">Simple Pricing</div>
+          <h2 className="font-poppins font-bold text-3xl md:text-4xl text-white mb-6">One plan. Unlimited clients.</h2>
+          <p className="text-slate-400 text-lg max-w-xl mx-auto leading-relaxed mb-12">
+            No tiers. No per-client fees. Just one flat monthly price that gives you and all your clients full access.
+          </p>
+
+          {/* Pricing Card */}
+          <div className="max-w-md mx-auto bg-[#1E293B] rounded-2xl border border-slate-700 p-8 shadow-2xl relative overflow-hidden">
+            <div className="absolute top-0 left-0 right-0 h-1 bg-gradient-to-r from-[#0EA5E9] to-[#6366F1]"></div>
+            
+            <div className="mb-6">
+              <h3 className="font-poppins font-bold text-2xl text-white mb-2">Claudia for Coaches</h3>
+              <p className="text-slate-400 text-sm">Everything you need to support your clients between sessions</p>
+            </div>
+
+            <div className="mb-8">
+              <div className="flex items-baseline justify-center gap-1">
+                <span className="text-5xl font-bold text-white font-poppins">£50</span>
+                <span className="text-slate-400 text-lg">/month</span>
+              </div>
+            </div>
+
+            <ul className="space-y-4 text-left mb-8">
+              <li className="flex items-start gap-3">
+                <CheckCircle2 size={20} className="text-emerald-400 flex-shrink-0 mt-0.5" />
+                <span className="text-slate-300">Unlimited client access</span>
+              </li>
+              <li className="flex items-start gap-3">
+                <CheckCircle2 size={20} className="text-emerald-400 flex-shrink-0 mt-0.5" />
+                <span className="text-slate-300">Full Pro plan features for everyone</span>
+              </li>
+              <li className="flex items-start gap-3">
+                <CheckCircle2 size={20} className="text-emerald-400 flex-shrink-0 mt-0.5" />
+                <span className="text-slate-300">Use it yourself as well</span>
+              </li>
+              <li className="flex items-start gap-3">
+                <CheckCircle2 size={20} className="text-emerald-400 flex-shrink-0 mt-0.5" />
+                <span className="text-slate-300">Coach analytics dashboard</span>
+              </li>
+              <li className="flex items-start gap-3">
+                <CheckCircle2 size={20} className="text-emerald-400 flex-shrink-0 mt-0.5" />
+                <span className="text-slate-300">Unlimited distribution to clients</span>
+              </li>
+              <li className="flex items-start gap-3">
+                <CheckCircle2 size={20} className="text-emerald-400 flex-shrink-0 mt-0.5" />
+                <span className="text-slate-300">Voice-first ADHD support</span>
+              </li>
+              <li className="flex items-start gap-3">
+                <CheckCircle2 size={20} className="text-emerald-400 flex-shrink-0 mt-0.5" />
+                <span className="text-slate-300">Task breakdown and daily planning</span>
+              </li>
+            </ul>
+
+            <button 
+              onClick={openCtaModal}
+              className="w-full bg-[#0EA5E9] hover:bg-[#0284C7] text-white font-bold text-lg py-4 rounded-xl transition-all shadow-lg shadow-cyan-500/25 hover:shadow-cyan-500/40 hover:-translate-y-1 flex items-center justify-center gap-2"
+            >
+              Get Started
+              <ArrowRight size={20} />
+            </button>
+          </div>
+        </div>
+      </section>
+
+      {/* Final CTA Section */}
+      <section className="py-24 bg-[#0F172A] relative">
+        <div className="absolute inset-0 bg-gradient-to-t from-slate-900 to-[#0F172A]"></div>
+        
+        <div className="max-w-4xl mx-auto px-6 text-center relative z-10">
+          <div className="bg-[#1E293B] p-12 rounded-2xl shadow-2xl border border-slate-700">
+            <h2 className="font-poppins font-bold text-3xl md:text-4xl text-white mb-6">Give your clients the support they deserve</h2>
+            <p className="text-xl text-slate-400 mb-10 leading-relaxed max-w-2xl mx-auto">
+              You cannot be available 24/7. But your clients can still have someone to talk to when they need it most. Help them implement what you teach, every single day.
+            </p>
+            <div className="flex justify-center">
+              <button 
+                onClick={openCtaModal}
+                className="w-full md:w-auto px-10 py-5 bg-[#0EA5E9] hover:bg-[#0284C7] text-white font-bold text-xl rounded-xl transition-all flex items-center justify-center gap-2 shadow-lg shadow-cyan-500/20 hover:-translate-y-1"
+              >
+                Get Started
+                <ArrowRight size={24} />
+              </button>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+      <LPFooter />
+      <Toaster />
+    </>
+  );
+};
+
+export default ForCoaches;


### PR DESCRIPTION
## New Page: For Coaches (/forcoaches)

Adds a dedicated landing page for ADHD coaches at `/forcoaches`.

### What's included:

- **Hero section** with coaching-specific copy about supporting clients between sessions
- **Problem section** highlighting the gap between coaching sessions (1am panic, implementation gap, slow progress)
- **Solution section** with 6 benefit cards explaining how Claudia helps coaches
- **Analytics placeholder** for a future screenshot of the coach dashboard
- **Competitive edge section** covering differentiation, better reviews, more referrals, and 10x ROI
- **Inline pricing** at £50/month flat (unlimited clients, full Pro features, unlimited distribution)
- **CTA modal** with two paths:
  - 'Talk to the Founder' (links to Motion booking page)
  - 'Send us your details' (opens Moosend form with Name, Email, Coach checkbox)
- **New API route** `/api/coach-enquiry` for Moosend subscription with `is_coach` custom field
- **Navigation update**: Added 'For Coaches' to the site-wide header dropdown (desktop + mobile)

### Design:
Matches the existing dark theme design language from For Clinics and For Corporates pages (same fonts, colors, glass-card components, gradient headlines, etc.).